### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: nugetPackage
-        path: bin/Release/*.nupkg
+        path: bin/Release/**/*.nupkg
 
   release:
     runs-on: ubuntu-latest    


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/dotnet.yml` file. The change modifies the path for the NuGet package artifact to include all subdirectories within the `bin/Release` directory.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L51-R51): Changed the artifact path from `bin/Release/*.nupkg` to `bin/Release/**/*.nupkg` to ensure all NuGet package files in subdirectories are included.