### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,7 +45,7 @@ jobs:
       run: dotnet pack ${{ vars.CS_PROJ_PATH }} -p:Version='${{ steps.gitversion.outputs.SemVer }}' -c Release
 
     - name: List build output
-      run: ls -R bin/Release
+      run: ls -R src/bin/Release
 
     - name: Upload NuGet package to GitHub
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/dotnet.yml` file. The change modifies the path in the `List build output` step to correctly point to the `src/bin/Release` directory instead of the `bin/Release` directory.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L48-R48): Updated the `run` command in the `List build output` step to use the correct directory path (`src/bin/Release`).