### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,7 +68,7 @@ jobs:
     
     - name: Push package to GitHub packages 
       if: needs.build.outputs.CommitsSinceVersionSource > 0 #Only release if there has been a commit/version change  
-      run: dotnet nuget push nugetPackage/*.nupkg --api-key ${{ secrets.NUGET_PACKAGE_TOKEN }} --source "github"
+      run: dotnet nuget push nugetPackage/*.nupkg --api-key ${{ secrets.NUGET_PACKAGE_TOKEN }} --source "github" --skip-duplicate
     
     - name: Push package to nuget.org
       if: needs.build.outputs.CommitsSinceVersionSource > 0


### PR DESCRIPTION
- [x] close #2 

This pull request includes a small but important change to the `.github/workflows/dotnet.yml` file. The change modifies the command used to push packages to GitHub packages, adding a flag to skip duplicates.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L71-R71): Added the `--skip-duplicate` flag to the `dotnet nuget push` command to prevent errors when attempting to push duplicate packages.