### PR TITLE
Sonarcloud issues fix

### DIFF
--- a/src/Client/WahaApiClient.cs
+++ b/src/Client/WahaApiClient.cs
@@ -37,7 +37,7 @@ namespace Waha
 
         #region [ SESSIONS ]
 
-        public async Task<IReadOnlyList<SessionShort>> GetSessionsAsync(bool all, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<SessionShort>> GetSessionsAsync(bool all, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions";
             url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
@@ -51,7 +51,7 @@ namespace Waha
             return result ?? new List<SessionShort>();
         }
 
-        public async Task<Session> CreateSessionAsync(SessionCreateRequest createRequest, CancellationToken cancellationToken)
+        public async Task<Session> CreateSessionAsync(SessionCreateRequest createRequest, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = await _httpClient.PostAsJsonAsync("/api/sessions", createRequest, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -60,7 +60,7 @@ namespace Waha
             return session ?? throw new InvalidOperationException("Session creation returned null");
         }
 
-        public async Task<Session> GetSessionAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<Session> GetSessionAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}";
             HttpResponseMessage response = await _httpClient.GetAsync(url, cancellationToken);
@@ -70,7 +70,7 @@ namespace Waha
             return session ?? throw new InvalidOperationException($"Session '{sessionName}' not found or returned null");
         }
 
-        public async Task<Session> UpdateSessionAsync(string sessionName, SessionUpdateRequest updateRequest, CancellationToken cancellationToken)
+        public async Task<Session> UpdateSessionAsync(string sessionName, SessionUpdateRequest updateRequest, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}";
             HttpResponseMessage response = await _httpClient.PutAsJsonAsync(url, updateRequest, cancellationToken);
@@ -80,14 +80,14 @@ namespace Waha
             return session ?? throw new InvalidOperationException($"Session '{sessionName}' update returned null");
         }
 
-        public async Task DeleteSessionAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task DeleteSessionAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}";
             HttpResponseMessage response = await _httpClient.DeleteAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<SessionUser> GetMySessionUserAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<SessionUser> GetMySessionUserAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}/me";
             HttpResponseMessage response = await _httpClient.GetAsync(url, cancellationToken);
@@ -97,7 +97,7 @@ namespace Waha
             return me ?? throw new InvalidOperationException($"Fetching 'me' from session '{sessionName}' returned null");
         }
 
-        public async Task<SessionShort> StartSessionAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<SessionShort> StartSessionAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}/start";
             HttpResponseMessage response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -107,7 +107,7 @@ namespace Waha
             return result ?? throw new InvalidOperationException($"Start session '{sessionName}' returned null");
         }
 
-        public async Task<SessionShort> StopSessionAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<SessionShort> StopSessionAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}/stop";
             HttpResponseMessage response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -117,7 +117,7 @@ namespace Waha
             return result ?? throw new InvalidOperationException($"Stop session '{sessionName}' returned null");
         }
 
-        public async Task<SessionShort> LogoutSessionAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<SessionShort> LogoutSessionAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}/logout";
             HttpResponseMessage response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -127,7 +127,7 @@ namespace Waha
             return result ?? throw new InvalidOperationException($"Logout session '{sessionName}' returned null");
         }
 
-        public async Task<SessionShort> RestartSessionAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<SessionShort> RestartSessionAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions/{sessionName}/restart";
             HttpResponseMessage response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -141,7 +141,7 @@ namespace Waha
 
         #region [ AUTH ]
 
-        public async Task<AuthQrResponse> GetAuthQrAsync(string sessionName, string format, CancellationToken cancellationToken)
+        public async Task<AuthQrResponse> GetAuthQrAsync(string sessionName, string format, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Starting auth via QR code for {SessionName} session", sessionName);
             var stopwatch = Stopwatch.StartNew();
@@ -176,7 +176,7 @@ namespace Waha
             }
         }
 
-        public async Task<AuthRequestCodeResponse> RequestAuthCodeAsync(string sessionName, AuthCodeRequest request, CancellationToken cancellationToken)
+        public async Task<AuthRequestCodeResponse> RequestAuthCodeAsync(string sessionName, AuthCodeRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync($"/api/{sessionName}/auth/request-code", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -189,7 +189,7 @@ namespace Waha
 
         #region [ PROFILE ]
 
-        public async Task<Profile> GetProfileAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<Profile> GetProfileAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Getting profile for {SessionName} session", sessionName);
             var stopwatch = Stopwatch.StartNew();
@@ -216,7 +216,7 @@ namespace Waha
             }
         }
 
-        public async Task<bool> UpdateProfileNameAsync(string sessionName, string name, CancellationToken cancellationToken)
+        public async Task<bool> UpdateProfileNameAsync(string sessionName, string name, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Updating profile name for {SessionName} session to '{Name}'", sessionName, name);
             var stopwatch = Stopwatch.StartNew();
@@ -242,7 +242,7 @@ namespace Waha
             }
         }
 
-        public async Task<bool> UpdateProfileAboutAsync(string sessionName, string about, CancellationToken cancellationToken)
+        public async Task<bool> UpdateProfileAboutAsync(string sessionName, string about, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Updating profile about for {SessionName} session", sessionName);
             var stopwatch = Stopwatch.StartNew();
@@ -268,7 +268,7 @@ namespace Waha
             }
         }
 
-        public async Task<bool> UpdateProfilePictureAsync(string sessionName, UpdateProfilePictureRequest updateProfilePictureRequest, CancellationToken cancellationToken)
+        public async Task<bool> UpdateProfilePictureAsync(string sessionName, UpdateProfilePictureRequest updateProfilePictureRequest, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Updating profile picture for {SessionName} session", sessionName);
             var stopwatch = Stopwatch.StartNew();
@@ -297,7 +297,7 @@ namespace Waha
 
         #region [ SCREENSHOT ]
 
-        public async Task<byte[]> GetScreenshotAsync(string session, CancellationToken cancellationToken)
+        public async Task<byte[]> GetScreenshotAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/screenshot?session={session}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -309,7 +309,7 @@ namespace Waha
 
         #region [ CHATTING ]
 
-        public async Task<Message> SendTextAsync(SendTextRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendTextAsync(SendTextRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendText", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -317,7 +317,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendText returned null");
         }
 
-        public async Task<Message> SendImageAsync(SendImageRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendImageAsync(SendImageRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendImage", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -325,7 +325,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendImage returned null");
         }
 
-        public async Task<Message> SendFileAsync(SendFileRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendFileAsync(SendFileRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendFile", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -333,7 +333,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendFile returned null");
         }
 
-        public async Task<Message> SendVoiceAsync(SendVoiceRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendVoiceAsync(SendVoiceRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendVoice", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -341,7 +341,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendVoice returned null");
         }
 
-        public async Task<Message> SendVideoAsync(SendVideoRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendVideoAsync(SendVideoRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendVideo", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -349,7 +349,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendVideo returned null");
         }
 
-        public async Task<Message> SendButtonsAsync(SendButtonsRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendButtonsAsync(SendButtonsRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendButtons", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -357,7 +357,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendButtons returned null");
         }
 
-        public async Task<Message> ForwardMessageAsync(ForwardMessageRequest request, CancellationToken cancellationToken)
+        public async Task<Message> ForwardMessageAsync(ForwardMessageRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/forwardMessage", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -365,25 +365,25 @@ namespace Waha
                    ?? throw new InvalidOperationException("ForwardMessage returned null");
         }
 
-        public async Task SendSeenAsync(SendSeenRequest request, CancellationToken cancellationToken)
+        public async Task SendSeenAsync(SendSeenRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendSeen", request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task StartTypingAsync(ChatRequest request, CancellationToken cancellationToken)
+        public async Task StartTypingAsync(ChatRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/startTyping", request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task StopTypingAsync(ChatRequest request, CancellationToken cancellationToken)
+        public async Task StopTypingAsync(ChatRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/stopTyping", request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<Message> SetReactionAsync(ReactionRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SetReactionAsync(ReactionRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PutAsJsonAsync("/api/reaction", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -391,13 +391,13 @@ namespace Waha
                    ?? throw new InvalidOperationException("SetReaction returned null");
         }
 
-        public async Task SetStarAsync(StarRequest request, CancellationToken cancellationToken)
+        public async Task SetStarAsync(StarRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PutAsJsonAsync("/api/star", request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<Message> SendPollAsync(SendPollRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendPollAsync(SendPollRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendPoll", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -405,7 +405,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendPoll returned null");
         }
 
-        public async Task<Message> SendLocationAsync(SendLocationRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendLocationAsync(SendLocationRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendLocation", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -413,7 +413,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendLocation returned null");
         }
 
-        public async Task<Message> SendLinkPreviewAsync(SendLinkPreviewRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendLinkPreviewAsync(SendLinkPreviewRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendLinkPreview", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -421,7 +421,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendLinkPreview returned null");
         }
 
-        public async Task<Message> SendContactVcardAsync(SendContactVcardRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendContactVcardAsync(SendContactVcardRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendContactVcard", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -433,7 +433,7 @@ namespace Waha
 
         #region [ CHANNELS ]
 
-        public async Task<IReadOnlyList<Channel>> SearchChannelsByViewAsync(string session, ChannelSearchByViewRequest request, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Channel>> SearchChannelsByViewAsync(string session, ChannelSearchByViewRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/search/by-view";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -442,7 +442,7 @@ namespace Waha
                    ?? new List<Channel>();
         }
 
-        public async Task<IReadOnlyList<Channel>> SearchChannelsByTextAsync(string session, ChannelSearchByTextRequest request, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Channel>> SearchChannelsByTextAsync(string session, ChannelSearchByTextRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/search/by-text";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -451,7 +451,7 @@ namespace Waha
                    ?? new List<Channel>();
         }
 
-        public async Task<IReadOnlyList<object>> GetChannelSearchViewsAsync(string session, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<object>> GetChannelSearchViewsAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/search/views";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -460,7 +460,7 @@ namespace Waha
                    ?? new List<object>();
         }
 
-        public async Task<IReadOnlyList<object>> GetChannelSearchCountriesAsync(string session, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<object>> GetChannelSearchCountriesAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/search/countries";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -469,7 +469,7 @@ namespace Waha
                    ?? new List<object>();
         }
 
-        public async Task<IReadOnlyList<object>> GetChannelSearchCategoriesAsync(string session, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<object>> GetChannelSearchCategoriesAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/search/categories";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -478,7 +478,7 @@ namespace Waha
                    ?? new List<object>();
         }
 
-        public async Task<IReadOnlyList<ChannelMessage>> PreviewChannelMessagesAsync(string session, string id, bool downloadMedia, int limit, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<ChannelMessage>> PreviewChannelMessagesAsync(string session, string id, bool downloadMedia, int limit, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{id}/messages/preview?downloadMedia={downloadMedia}&limit={limit}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -487,7 +487,7 @@ namespace Waha
                    ?? new List<ChannelMessage>();
         }
 
-        public async Task<IReadOnlyList<Channel>> GetChannelsAsync(string session, string? role, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Channel>> GetChannelsAsync(string session, string? role, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels";
             if (!string.IsNullOrEmpty(role)) url += $"?role={role}";
@@ -498,7 +498,7 @@ namespace Waha
                    ?? new List<Channel>();
         }
 
-        public async Task<Channel> CreateChannelAsync(string session, CreateChannelRequest createChannelRequest, CancellationToken cancellationToken)
+        public async Task<Channel> CreateChannelAsync(string session, CreateChannelRequest createChannelRequest, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels";
             var response = await _httpClient.PostAsJsonAsync(url, createChannelRequest, cancellationToken);
@@ -507,14 +507,14 @@ namespace Waha
                    ?? throw new InvalidOperationException("CreateChannel returned null");
         }
 
-        public async Task DeleteChannelAsync(string session, string channelId, CancellationToken cancellationToken)
+        public async Task DeleteChannelAsync(string session, string channelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{channelId}";
             var response = await _httpClient.DeleteAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<Channel> GetChannelAsync(string session, string channelIdOrInvite, CancellationToken cancellationToken)
+        public async Task<Channel> GetChannelAsync(string session, string channelIdOrInvite, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{channelIdOrInvite}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -523,28 +523,28 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetChannel returned null");
         }
 
-        public async Task FollowChannelAsync(string session, string channelId, CancellationToken cancellationToken)
+        public async Task FollowChannelAsync(string session, string channelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{channelId}/follow";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task UnfollowChannelAsync(string session, string channelId, CancellationToken cancellationToken)
+        public async Task UnfollowChannelAsync(string session, string channelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{channelId}/unfollow";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task MuteChannelAsync(string session, string channelId, CancellationToken cancellationToken)
+        public async Task MuteChannelAsync(string session, string channelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{channelId}/mute";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task UnmuteChannelAsync(string session, string channelId, CancellationToken cancellationToken)
+        public async Task UnmuteChannelAsync(string session, string channelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/channels/{channelId}/unmute";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -555,35 +555,35 @@ namespace Waha
 
         #region [ STATUS ]
 
-        public async Task SendTextStatusAsync(string session, TextStatusRequest request, CancellationToken cancellationToken)
+        public async Task SendTextStatusAsync(string session, TextStatusRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/status/text";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task SendImageStatusAsync(string session, ImageStatusRequest request, CancellationToken cancellationToken)
+        public async Task SendImageStatusAsync(string session, ImageStatusRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/status/image";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task SendVoiceStatusAsync(string session, VoiceStatusRequest request, CancellationToken cancellationToken)
+        public async Task SendVoiceStatusAsync(string session, VoiceStatusRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/status/voice";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task SendVideoStatusAsync(string session, VideoStatusRequest request, CancellationToken cancellationToken)
+        public async Task SendVideoStatusAsync(string session, VideoStatusRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/status/video";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task DeleteStatusAsync(string session, DeleteStatusRequest request, CancellationToken cancellationToken)
+        public async Task DeleteStatusAsync(string session, DeleteStatusRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/status/delete";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -594,7 +594,7 @@ namespace Waha
 
         #region [ CHATS ]
 
-        public async Task<IReadOnlyList<Chat>> GetChatsAsync(string session, int limit, int offset, string sortBy, string sortOrder, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Chat>> GetChatsAsync(string session, int limit, int offset, string sortBy, string sortOrder, CancellationToken cancellationToken = default)
         {
             var queryStringParameters = new Dictionary<string, string>
             {
@@ -615,7 +615,7 @@ namespace Waha
             return chats ?? new List<Chat>();
         }
 
-        public async Task<IReadOnlyList<ChatOverview>> GetChatsOverviewAsync(string session, int limit, int offset, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<ChatOverview>> GetChatsOverviewAsync(string session, int limit, int offset, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/overview";
             url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
@@ -630,13 +630,13 @@ namespace Waha
             return overview ?? new List<ChatOverview>();
         }
 
-        public async Task DeleteChatAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task DeleteChatAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.DeleteAsync($"/api/{session}/chats/{chatId}", cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<ChatPicture> GetChatPictureAsync(string session, string chatId, bool refresh, CancellationToken cancellationToken)
+        public async Task<ChatPicture> GetChatPictureAsync(string session, string chatId, bool refresh, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/{chatId}/picture";
             url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
@@ -650,7 +650,7 @@ namespace Waha
             return picture ?? throw new InvalidOperationException("Unable to deserialize chat picture.");
         }
 
-        public async Task<IReadOnlyList<ChatMessage>> GetChatMessagesAsync(string session, string chatId, int limit, int offset, string filterTimestampLte, string filterTimestampGte, bool? filterOnlyMyMessages, bool downloadMedia, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<ChatMessage>> GetChatMessagesAsync(string session, string chatId, int limit, int offset, string filterTimestampLte, string filterTimestampGte, bool? filterOnlyMyMessages, bool downloadMedia, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/{chatId}/messages";
             url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
@@ -673,7 +673,7 @@ namespace Waha
             return messages ?? new List<ChatMessage>();
         }
 
-        public async Task<ChatMessage> SendChatMessageAsync(string session, string chatId, CreateChatMessageRequest request, CancellationToken cancellationToken)
+        public async Task<ChatMessage> SendChatMessageAsync(string session, string chatId, CreateChatMessageRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync($"/api/{session}/chats/{chatId}/messages", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -682,13 +682,13 @@ namespace Waha
             return message ?? throw new InvalidOperationException("Unable to deserialize created message.");
         }
 
-        public async Task ClearChatMessagesAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task ClearChatMessagesAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.DeleteAsync($"/api/{session}/chats/{chatId}/messages", cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<ChatMessage> GetChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken)
+        public async Task<ChatMessage> GetChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.GetAsync($"/api/{session}/chats/{chatId}/messages/{messageId}", cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -697,13 +697,13 @@ namespace Waha
             return message ?? throw new InvalidOperationException("Unable to deserialize chat message.");
         }
 
-        public async Task DeleteChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken)
+        public async Task DeleteChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.DeleteAsync($"/api/{session}/chats/{chatId}/messages/{messageId}", cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<ChatMessage> EditChatMessageAsync(string session, string chatId, string messageId, EditChatMessageRequest request, CancellationToken cancellationToken)
+        public async Task<ChatMessage> EditChatMessageAsync(string session, string chatId, string messageId, EditChatMessageRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PutAsJsonAsync($"/api/{session}/chats/{chatId}/messages/{messageId}", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -712,31 +712,31 @@ namespace Waha
             return edited ?? throw new InvalidOperationException("Unable to deserialize edited message.");
         }
 
-        public async Task PinChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken)
+        public async Task PinChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsync($"/api/{session}/chats/{chatId}/messages/{messageId}/pin", content: null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task UnpinChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken)
+        public async Task UnpinChatMessageAsync(string session, string chatId, string messageId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsync($"/api/{session}/chats/{chatId}/messages/{messageId}/unpin", content: null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task ArchiveChatAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task ArchiveChatAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsync($"/api/{session}/chats/{chatId}/archive", content: null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task UnarchiveChatAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task UnarchiveChatAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsync($"/api/{session}/chats/{chatId}/unarchive", content: null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task UnreadChatAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task UnreadChatAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsync($"/api/{session}/chats/{chatId}/unread", content: null, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -746,7 +746,7 @@ namespace Waha
 
         #region [ CONTACTS ]
 
-        public async Task<IReadOnlyList<Contact>> GetAllContactsAsync(string session, int limit, int offset, string sortAsc, string sortOrder, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Contact>> GetAllContactsAsync(string session, int limit, int offset, string sortAsc, string sortOrder, CancellationToken cancellationToken = default)
         {
             var url = $"/api/contacts/all";
             url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
@@ -767,7 +767,7 @@ namespace Waha
                    ?? new List<Contact>();
         }
 
-        public async Task<object?> GetContactAsync(string session, string contactId, CancellationToken cancellationToken)
+        public async Task<object?> GetContactAsync(string session, string contactId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/contacts?contactId={contactId}&session={session}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -775,7 +775,7 @@ namespace Waha
             return await response.Content.ReadFromJsonAsync<object>(cancellationToken: cancellationToken);
         }
 
-        public async Task<NumberExistResult> CheckContactExistsAsync(string session, string phone, CancellationToken cancellationToken)
+        public async Task<NumberExistResult> CheckContactExistsAsync(string session, string phone, CancellationToken cancellationToken = default)
         {
             var url = $"/api/contacts/check-exists?phone={phone}&session={session}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -784,7 +784,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("CheckContactExists returned null");
         }
 
-        public async Task<string?> GetContactAboutAsync(string session, string contactId, CancellationToken cancellationToken)
+        public async Task<string?> GetContactAboutAsync(string session, string contactId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/contacts/about?contactId={contactId}&session={session}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -792,7 +792,7 @@ namespace Waha
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
-        public async Task<string?> GetContactProfilePictureAsync(string session, string contactId, bool refresh, CancellationToken cancellationToken)
+        public async Task<string?> GetContactProfilePictureAsync(string session, string contactId, bool refresh, CancellationToken cancellationToken = default)
         {
             var url = $"/api/contacts/profile-picture?contactId={contactId}&refresh={refresh}&session={session}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -800,14 +800,14 @@ namespace Waha
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
-        public async Task BlockContactAsync(string session, string contactId, CancellationToken cancellationToken)
+        public async Task BlockContactAsync(string session, string contactId, CancellationToken cancellationToken = default)
         {
             var body = new { contactId, session };
             var response = await _httpClient.PostAsJsonAsync("/api/contacts/block", body, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task UnblockContactAsync(string session, string contactId, CancellationToken cancellationToken)
+        public async Task UnblockContactAsync(string session, string contactId, CancellationToken cancellationToken = default)
         {
             var body = new { contactId, session };
             var response = await _httpClient.PostAsJsonAsync("/api/contacts/unblock", body, cancellationToken);
@@ -818,7 +818,7 @@ namespace Waha
 
         #region [ GROUPS ]
 
-        public async Task<Group> CreateGroupAsync(string session, CreateGroupRequest request, CancellationToken cancellationToken)
+        public async Task<Group> CreateGroupAsync(string session, CreateGroupRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -827,7 +827,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("CreateGroup returned null");
         }
 
-        public async Task<IReadOnlyList<Group>> GetGroupsAsync(string session, bool? sortAsc, string? sortBy, int? limit, int? offset, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Group>> GetGroupsAsync(string session, bool? sortAsc, string? sortBy, int? limit, int? offset, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups";
             if (sortBy != null) url += $"?sortBy={sortBy}";
@@ -841,7 +841,7 @@ namespace Waha
                    ?? new List<Group>();
         }
 
-        public async Task<object?> GetGroupJoinInfoAsync(string session, string code, CancellationToken cancellationToken)
+        public async Task<object?> GetGroupJoinInfoAsync(string session, string code, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/join-info?code={code}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -849,7 +849,7 @@ namespace Waha
             return await response.Content.ReadFromJsonAsync<object>(cancellationToken: cancellationToken);
         }
 
-        public async Task<JoinGroupResponse> JoinGroupAsync(string session, JoinGroupRequest request, CancellationToken cancellationToken)
+        public async Task<JoinGroupResponse> JoinGroupAsync(string session, JoinGroupRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/join";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -858,14 +858,14 @@ namespace Waha
                    ?? throw new InvalidOperationException("JoinGroup returned null");
         }
 
-        public async Task RefreshGroupsAsync(string session, CancellationToken cancellationToken)
+        public async Task RefreshGroupsAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/refresh";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<Group> GetGroupAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<Group> GetGroupAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -874,14 +874,14 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetGroup returned null");
         }
 
-        public async Task DeleteGroupAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task DeleteGroupAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}";
             var response = await _httpClient.DeleteAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<SettingsSecurityChangeRequest> SetGroupInfoAdminOnlyAsync(string session, string groupId, SettingsSecurityChangeRequest request, CancellationToken cancellationToken)
+        public async Task<SettingsSecurityChangeRequest> SetGroupInfoAdminOnlyAsync(string session, string groupId, SettingsSecurityChangeRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/settings/security/info-admin-only";
             var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
@@ -890,7 +890,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SetGroupInfoAdminOnly returned null");
         }
 
-        public async Task<SettingsSecurityChangeRequest> GetGroupInfoAdminOnlyAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<SettingsSecurityChangeRequest> GetGroupInfoAdminOnlyAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/settings/security/info-admin-only";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -899,7 +899,7 @@ namespace Waha
                    ?? new SettingsSecurityChangeRequest();
         }
 
-        public async Task<SettingsSecurityChangeRequest> SetGroupMessagesAdminOnlyAsync(string session, string groupId, SettingsSecurityChangeRequest request, CancellationToken cancellationToken)
+        public async Task<SettingsSecurityChangeRequest> SetGroupMessagesAdminOnlyAsync(string session, string groupId, SettingsSecurityChangeRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/settings/security/messages-admin-only";
             var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
@@ -908,7 +908,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SetGroupMessagesAdminOnly returned null");
         }
 
-        public async Task<SettingsSecurityChangeRequest> GetGroupMessagesAdminOnlyAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<SettingsSecurityChangeRequest> GetGroupMessagesAdminOnlyAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/settings/security/messages-admin-only";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -917,28 +917,28 @@ namespace Waha
                    ?? new SettingsSecurityChangeRequest();
         }
 
-        public async Task LeaveGroupAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task LeaveGroupAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/leave";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task SetGroupDescriptionAsync(string session, string groupId, DescriptionRequest request, CancellationToken cancellationToken)
+        public async Task SetGroupDescriptionAsync(string session, string groupId, DescriptionRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/description";
             var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task SetGroupSubjectAsync(string session, string groupId, SubjectRequest request, CancellationToken cancellationToken)
+        public async Task SetGroupSubjectAsync(string session, string groupId, SubjectRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/subject";
             var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<string> GetGroupInviteCodeAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<string> GetGroupInviteCodeAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/invite-code";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -946,7 +946,7 @@ namespace Waha
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
-        public async Task<string> RevokeGroupInviteCodeAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<string> RevokeGroupInviteCodeAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/invite-code/revoke";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -954,7 +954,7 @@ namespace Waha
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
 
-        public async Task<object?> GetGroupParticipantsAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<object?> GetGroupParticipantsAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/participants";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -962,28 +962,28 @@ namespace Waha
             return await response.Content.ReadFromJsonAsync<object>(cancellationToken: cancellationToken);
         }
 
-        public async Task AddGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken)
+        public async Task AddGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/participants/add";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task RemoveGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken)
+        public async Task RemoveGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/participants/remove";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task PromoteGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken)
+        public async Task PromoteGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/admin/promote";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task DemoteGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken)
+        public async Task DemoteGroupParticipantsAsync(string session, string groupId, ParticipantsRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/admin/demote";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -994,14 +994,14 @@ namespace Waha
 
         #region [ PRESENCES ]
 
-        public async Task SetSessionPresenceAsync(string session, SessionPresenceRequest request, CancellationToken cancellationToken)
+        public async Task SetSessionPresenceAsync(string session, SessionPresenceRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/presence";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<IReadOnlyList<ChatPresences>> GetAllPresencesAsync(string session, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<ChatPresences>> GetAllPresencesAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/presence";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1010,7 +1010,7 @@ namespace Waha
                    ?? new List<ChatPresences>();
         }
 
-        public async Task<ChatPresences> GetPresenceAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task<ChatPresences> GetPresenceAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/presence/{chatId}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1019,7 +1019,7 @@ namespace Waha
                    ?? new ChatPresences { ChatId = chatId };
         }
 
-        public async Task SubscribePresenceAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task SubscribePresenceAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/presence/{chatId}/subscribe";
             var response = await _httpClient.PostAsync(url, null, cancellationToken);
@@ -1030,7 +1030,7 @@ namespace Waha
 
         #region [ LABELS ]
 
-        public async Task<IReadOnlyList<Label>> GetAllLabelsAsync(string session, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Label>> GetAllLabelsAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1039,7 +1039,7 @@ namespace Waha
                    ?? new List<Label>();
         }
 
-        public async Task<Label> CreateLabelAsync(string session, LabelRequest body, CancellationToken cancellationToken)
+        public async Task<Label> CreateLabelAsync(string session, LabelRequest body, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels";
             var response = await _httpClient.PostAsJsonAsync(url, body, cancellationToken);
@@ -1048,7 +1048,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("CreateLabel returned null");
         }
 
-        public async Task<Label> UpdateLabelAsync(string session, string labelId, LabelRequest body, CancellationToken cancellationToken)
+        public async Task<Label> UpdateLabelAsync(string session, string labelId, LabelRequest body, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels/{labelId}";
             var response = await _httpClient.PutAsJsonAsync(url, body, cancellationToken);
@@ -1057,14 +1057,14 @@ namespace Waha
                    ?? throw new InvalidOperationException("UpdateLabel returned null");
         }
 
-        public async Task DeleteLabelAsync(string session, string labelId, CancellationToken cancellationToken)
+        public async Task DeleteLabelAsync(string session, string labelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels/{labelId}";
             var response = await _httpClient.DeleteAsync(url, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<IReadOnlyList<Label>> GetLabelsForChatAsync(string session, string chatId, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Label>> GetLabelsForChatAsync(string session, string chatId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels/chats/{chatId}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1073,14 +1073,14 @@ namespace Waha
                    ?? new List<Label>();
         }
 
-        public async Task PutLabelsForChatAsync(string session, string chatId, SetLabelsRequest request, CancellationToken cancellationToken)
+        public async Task PutLabelsForChatAsync(string session, string chatId, SetLabelsRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels/chats/{chatId}";
             var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task<object?> GetChatsByLabelAsync(string session, string labelId, CancellationToken cancellationToken)
+        public async Task<object?> GetChatsByLabelAsync(string session, string labelId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/labels/{labelId}/chats";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1092,7 +1092,7 @@ namespace Waha
 
         #region [ OBSERVABILITY ]
 
-        public async Task<PingResponse> PingAsync(CancellationToken cancellationToken)
+        public async Task<PingResponse> PingAsync(CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.GetAsync("/ping", cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1100,7 +1100,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("Ping returned null");
         }
 
-        public async Task<HealthResponse> CheckHealthAsync(CancellationToken cancellationToken)
+        public async Task<HealthResponse> CheckHealthAsync(CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.GetAsync("/health", cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1108,7 +1108,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("CheckHealth returned null");
         }
 
-        public async Task<Environment> GetServerVersionAsync(CancellationToken cancellationToken)
+        public async Task<Environment> GetServerVersionAsync(CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.GetAsync("/api/server/version", cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1116,7 +1116,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetServerVersion returned null");
         }
 
-        public async Task<object?> GetServerEnvironmentAsync(bool all, CancellationToken cancellationToken)
+        public async Task<object?> GetServerEnvironmentAsync(bool all, CancellationToken cancellationToken = default)
         {
             var url = $"/api/server/environment?all={all}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1124,7 +1124,7 @@ namespace Waha
             return await response.Content.ReadFromJsonAsync<object>(cancellationToken: cancellationToken);
         }
 
-        public async Task<ServerStatusResponse> GetServerStatusAsync(CancellationToken cancellationToken)
+        public async Task<ServerStatusResponse> GetServerStatusAsync(CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.GetAsync("/api/server/status", cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1132,7 +1132,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetServerStatus returned null");
         }
 
-        public async Task<StopResponse> StopServerAsync(StopRequest request, CancellationToken cancellationToken)
+        public async Task<StopResponse> StopServerAsync(StopRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/server/stop", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1140,7 +1140,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("StopServer returned null");
         }
 
-        public async Task<byte[]> GetHeapSnapshotAsync(CancellationToken cancellationToken)
+        public async Task<byte[]> GetHeapSnapshotAsync(CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.GetAsync("/api/server/debug/heapsnapshot", cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1151,7 +1151,7 @@ namespace Waha
 
         #region [ CALLS ]
 
-        public async Task RejectCallAsync(string session, RejectCallRequest request, CancellationToken cancellationToken)
+        public async Task RejectCallAsync(string session, RejectCallRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/calls/reject";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -1162,7 +1162,7 @@ namespace Waha
 
         #region [ LIDS ]
 
-        public async Task<IReadOnlyList<LidToPhoneNumber>> GetAllLidsAsync(string session, int limit, int offset, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<LidToPhoneNumber>> GetAllLidsAsync(string session, int limit, int offset, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/lids";
             var queryParams = new Dictionary<string, string?>
@@ -1177,7 +1177,7 @@ namespace Waha
                    ?? new List<LidToPhoneNumber>();
         }
 
-        public async Task<CountResponse> GetLidsCountAsync(string session, CancellationToken cancellationToken)
+        public async Task<CountResponse> GetLidsCountAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/lids/count";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1186,7 +1186,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetLidsCount returned null");
         }
 
-        public async Task<LidToPhoneNumber> GetPhoneByLidAsync(string session, string lid, CancellationToken cancellationToken)
+        public async Task<LidToPhoneNumber> GetPhoneByLidAsync(string session, string lid, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/lids/{lid}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1195,7 +1195,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetPhoneByLid returned null");
         }
 
-        public async Task<LidToPhoneNumber> GetLidByPhoneAsync(string session, string phoneNumber, CancellationToken cancellationToken)
+        public async Task<LidToPhoneNumber> GetLidByPhoneAsync(string session, string phoneNumber, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/lids/pn/{phoneNumber}";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1208,7 +1208,7 @@ namespace Waha
 
         #region [ MEDIA ]
 
-        public async Task<byte[]> ConvertVoiceAsync(string session, MediaConvertRequest request, CancellationToken cancellationToken)
+        public async Task<byte[]> ConvertVoiceAsync(string session, MediaConvertRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/media/convert/voice";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -1216,7 +1216,7 @@ namespace Waha
             return await response.Content.ReadAsByteArrayAsync(cancellationToken);
         }
 
-        public async Task<byte[]> ConvertVideoAsync(string session, MediaConvertRequest request, CancellationToken cancellationToken)
+        public async Task<byte[]> ConvertVideoAsync(string session, MediaConvertRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/media/convert/video";
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
@@ -1228,7 +1228,7 @@ namespace Waha
 
         #region [ ADDITIONAL CHATTING ]
 
-        public async Task<Message> SendListAsync(SendListRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendListAsync(SendListRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendList", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1236,7 +1236,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendList returned null");
         }
 
-        public async Task<Message> SendLinkCustomPreviewAsync(SendLinkCustomPreviewRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendLinkCustomPreviewAsync(SendLinkCustomPreviewRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/send/link-custom-preview", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1244,7 +1244,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendLinkCustomPreview returned null");
         }
 
-        public async Task<Message> SendPollVoteAsync(SendPollVoteRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendPollVoteAsync(SendPollVoteRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/sendPollVote", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1252,7 +1252,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendPollVote returned null");
         }
 
-        public async Task<Message> SendButtonsReplyAsync(SendButtonsReplyRequest request, CancellationToken cancellationToken)
+        public async Task<Message> SendButtonsReplyAsync(SendButtonsReplyRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync("/api/send/buttons/reply", request, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -1260,7 +1260,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("SendButtonsReply returned null");
         }
 
-        public async Task<ReadMessagesResponse> ReadChatMessagesAsync(string session, string chatId, List<string>? messageIds, int days, CancellationToken cancellationToken)
+        public async Task<ReadMessagesResponse> ReadChatMessagesAsync(string session, string chatId, List<string>? messageIds, int days, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/{chatId}/messages/read";
             var queryParams = new Dictionary<string, string?>
@@ -1282,7 +1282,7 @@ namespace Waha
 
         #region [ ADDITIONAL GROUPS ]
 
-        public async Task<CountResponse> GetGroupsCountAsync(string session, CancellationToken cancellationToken)
+        public async Task<CountResponse> GetGroupsCountAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/count";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1291,7 +1291,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetGroupsCount returned null");
         }
 
-        public async Task<ChatPicture> GetGroupPictureAsync(string session, string groupId, bool refresh, CancellationToken cancellationToken)
+        public async Task<ChatPicture> GetGroupPictureAsync(string session, string groupId, bool refresh, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/picture";
             var queryParams = new Dictionary<string, string?>
@@ -1305,7 +1305,7 @@ namespace Waha
                    ?? throw new InvalidOperationException("GetGroupPicture returned null");
         }
 
-        public async Task<SuccessResponse> SetGroupPictureAsync(string session, string groupId, UpdateProfilePictureRequest request, CancellationToken cancellationToken)
+        public async Task<SuccessResponse> SetGroupPictureAsync(string session, string groupId, UpdateProfilePictureRequest request, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/picture";
             var response = await _httpClient.PutAsJsonAsync(url, request, cancellationToken);
@@ -1314,7 +1314,7 @@ namespace Waha
                    ?? new SuccessResponse { Success = true };
         }
 
-        public async Task<SuccessResponse> DeleteGroupPictureAsync(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<SuccessResponse> DeleteGroupPictureAsync(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/picture";
             var response = await _httpClient.DeleteAsync(url, cancellationToken);
@@ -1323,7 +1323,7 @@ namespace Waha
                    ?? new SuccessResponse { Success = true };
         }
 
-        public async Task<IReadOnlyList<GroupParticipantV2>> GetGroupParticipantsV2Async(string session, string groupId, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<GroupParticipantV2>> GetGroupParticipantsV2Async(string session, string groupId, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/groups/{groupId}/participants/v2";
             var response = await _httpClient.GetAsync(url, cancellationToken);
@@ -1336,7 +1336,7 @@ namespace Waha
 
         #region [ ADDITIONAL PROFILE ]
 
-        public async Task<bool> DeleteProfilePictureAsync(string sessionName, CancellationToken cancellationToken)
+        public async Task<bool> DeleteProfilePictureAsync(string sessionName, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{sessionName}/profile/picture";
             var response = await _httpClient.DeleteAsync(url, cancellationToken);
@@ -1345,7 +1345,7 @@ namespace Waha
             return result?.Success ?? true;
         }
 
-        public async Task<bool> SetProfileStatusAsync(string sessionName, string status, CancellationToken cancellationToken)
+        public async Task<bool> SetProfileStatusAsync(string sessionName, string status, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{sessionName}/profile/status";
             var requestBody = new { status };
@@ -1359,7 +1359,7 @@ namespace Waha
 
         #region [ ADDITIONAL STATUS ]
 
-        public async Task<NewMessageIdResponse> GetNewStatusMessageIdAsync(string session, CancellationToken cancellationToken)
+        public async Task<NewMessageIdResponse> GetNewStatusMessageIdAsync(string session, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/status/new-message-id";
             var response = await _httpClient.GetAsync(url, cancellationToken);

--- a/src/Client/WahaApiClient.cs
+++ b/src/Client/WahaApiClient.cs
@@ -40,7 +40,7 @@ namespace Waha
         public async Task<IReadOnlyList<SessionShort>> GetSessionsAsync(bool all, CancellationToken cancellationToken = default)
         {
             string url = $"/api/sessions";
-            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
+            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string?>
             {
                 ["all"] = all.ToString()
             });
@@ -149,7 +149,7 @@ namespace Waha
             try
             {
                 var url = $"/api/{sessionName}/auth/qr";
-                url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
+                url = QueryHelpers.AddQueryString(url, new Dictionary<string, string?>
                 {
                     ["format"] = format
                 });
@@ -596,7 +596,7 @@ namespace Waha
 
         public async Task<IReadOnlyList<Chat>> GetChatsAsync(string session, int limit, int offset, string sortBy, string sortOrder, CancellationToken cancellationToken = default)
         {
-            var queryStringParameters = new Dictionary<string, string>
+            var queryStringParameters = new Dictionary<string, string?>
             {
                 ["limit"] = limit.ToString(),
                 ["offset"] = offset.ToString()
@@ -618,7 +618,7 @@ namespace Waha
         public async Task<IReadOnlyList<ChatOverview>> GetChatsOverviewAsync(string session, int limit, int offset, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/overview";
-            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
+            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string?>
             {
                 ["limit"] = limit.ToString(),
                 ["offset"] = offset.ToString()
@@ -639,7 +639,7 @@ namespace Waha
         public async Task<ChatPicture> GetChatPictureAsync(string session, string chatId, bool refresh, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/{chatId}/picture";
-            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
+            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string?>
             {
                 ["refresh"] = refresh.ToString()
             });
@@ -653,7 +653,7 @@ namespace Waha
         public async Task<IReadOnlyList<ChatMessage>> GetChatMessagesAsync(string session, string chatId, int limit, int offset, string filterTimestampLte, string filterTimestampGte, bool? filterOnlyMyMessages, bool downloadMedia, CancellationToken cancellationToken = default)
         {
             var url = $"/api/{session}/chats/{chatId}/messages";
-            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
+            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string?>
             {
                 ["limit"] = limit.ToString(),
                 ["offset"] = offset.ToString(),
@@ -749,7 +749,7 @@ namespace Waha
         public async Task<IReadOnlyList<Contact>> GetAllContactsAsync(string session, int limit, int offset, string sortAsc, string sortOrder, CancellationToken cancellationToken = default)
         {
             var url = $"/api/contacts/all";
-            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string>
+            url = QueryHelpers.AddQueryString(url, new Dictionary<string, string?>
             {
                 ["session"] = session,
                 ["limit"] = limit.ToString(),

--- a/src/Client/WahaEntities.cs
+++ b/src/Client/WahaEntities.cs
@@ -152,7 +152,7 @@ namespace Waha
         public string Url { get; set; } = default!;
 
         [JsonPropertyName("events")]
-        public List<string> Events { get; set; } = new();
+        public List<string> Events { get; set; } = [];
 
         [JsonPropertyName("hmac")]
         public HmacConfiguration? Hmac { get; set; }
@@ -381,7 +381,7 @@ namespace Waha
         public string? FileName { get; set; }
 
         [JsonPropertyName("s3")]
-        public MediaS3Reference S3 { get; set; }
+        public MediaS3Reference? S3 { get; set; }
 
         [JsonPropertyName("error")]
         public string? Error { get; set; }
@@ -651,7 +651,7 @@ namespace Waha
         public string Question { get; set; } = default!;
 
         [JsonPropertyName("options")]
-        public List<string> Options { get; set; } = new();
+        public List<string> Options { get; set; } = [];
 
         [JsonPropertyName("multipleAnswers")]
         public bool IsMultipleAnswers { get; set; } = false;
@@ -660,11 +660,14 @@ namespace Waha
     public class SendPollResponsePoll
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
+
         [JsonPropertyName("to")]
-        public string To { get; set; }
+        public string? To { get; set; }
+
         [JsonPropertyName("from")]
-        public string From { get; set; }
+        public string? From { get; set; }
+
         [JsonPropertyName("fromMe")]
         public bool FromMe { get; set; }
     }
@@ -672,28 +675,28 @@ namespace Waha
     public class SendPollResponse
     {
         [JsonPropertyName("vote")]
-        public SendPollResponseVote Vote { get; set; }
+        public SendPollResponseVote? Vote { get; set; }
 
         [JsonPropertyName("poll")]
-        public SendPollResponsePoll Poll { get; set; }
+        public SendPollResponsePoll? Poll { get; set; }
     }
 
     public class SendPollResponseVote
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonPropertyName("to")]
-        public string To { get; set; }
+        public string? To { get; set; }
 
         [JsonPropertyName("from")]
-        public string From { get; set; }
+        public string? From { get; set; }
 
         [JsonPropertyName("fromMe")]
         public bool FromMe { get; set; }
 
         [JsonPropertyName("selectedOptions")]
-        public List<string> SelectedOptions { get; set; }
+        public List<string> SelectedOptions { get; set; } = [];
 
         [JsonPropertyName("timestamp")]
         public long Timestamp { get; set; }
@@ -895,7 +898,7 @@ namespace Waha
     public record ChannelListResult
     {
         [JsonPropertyName("channels")]
-        public List<Channel> Channels { get; set; } = new();
+        public List<Channel> Channels { get; set; } = [];
     }
 
     #endregion
@@ -959,7 +962,7 @@ namespace Waha
     public record DeleteStatusRequest
     {
         [JsonPropertyName("messageIds")]
-        public List<string> MessageIds { get; set; } = new();
+        public List<string> MessageIds { get; set; } = [];
     }
 
     #endregion
@@ -1153,7 +1156,7 @@ namespace Waha
         public string Subject { get; set; } = default!;
 
         [JsonPropertyName("participants")]
-        public List<string> Participants { get; set; } = new();
+        public List<string> Participants { get; set; } = [];
     }
 
     /// <summary>
@@ -1192,7 +1195,7 @@ namespace Waha
     public record ParticipantsRequest
     {
         [JsonPropertyName("participants")]
-        public List<string> Participants { get; set; } = new();
+        public List<string> Participants { get; set; } = [];
     }
 
     /// <summary>
@@ -1269,7 +1272,7 @@ namespace Waha
     public record SetLabelsRequest
     {
         [JsonPropertyName("labelIds")]
-        public List<string> LabelIds { get; set; } = new();
+        public List<string> LabelIds { get; set; } = [];
     }
 
     #endregion
@@ -1352,28 +1355,28 @@ namespace Waha
     public class WebhookEvent
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonPropertyName("session")]
-        public string Session { get; set; }
+        public string? Session { get; set; }
 
         [JsonPropertyName("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
+        public Dictionary<string, string> Metadata { get; set; } = [];
 
         [JsonPropertyName("engine")]
-        public string Engine { get; set; }
+        public string? Engine { get; set; }
 
         [JsonPropertyName("event")]
-        public string Event { get; set; }
+        public string? Event { get; set; }
 
         [JsonPropertyName("payload")]
-        public object Payload { get; set; }
+        public object? Payload { get; set; }
 
         [JsonPropertyName("me")]
-        public SessionUser Me { get; set; }
+        public SessionUser? Me { get; set; }
 
         [JsonPropertyName("environment")]
-        public Environment Environment { get; set; }
+        public Environment? Environment { get; set; }
     }
 
     #endregion
@@ -1467,7 +1470,7 @@ namespace Waha
         public string ButtonText { get; set; } = default!;
 
         [JsonPropertyName("sections")]
-        public List<ListSection> Sections { get; set; } = new();
+        public List<ListSection> Sections { get; set; } = [];
     }
 
     /// <summary>
@@ -1479,7 +1482,7 @@ namespace Waha
         public string Title { get; set; } = default!;
 
         [JsonPropertyName("rows")]
-        public List<ListRow> Rows { get; set; } = new();
+        public List<ListRow> Rows { get; set; } = [];
     }
 
     /// <summary>
@@ -1563,7 +1566,7 @@ namespace Waha
         public string PollMessageId { get; set; } = default!;
 
         [JsonPropertyName("options")]
-        public List<string> Options { get; set; } = new();
+        public List<string> Options { get; set; } = [];
     }
 
     /// <summary>

--- a/src/Client/WahaExtension.cs
+++ b/src/Client/WahaExtension.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Waha;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Microsoft.Extensions.Hosting
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 {
     /// <summary>
     /// Provides extension methods for configuring and adding the Waha API client to the host application builder.
@@ -46,7 +48,11 @@ namespace Microsoft.Extensions.Hosting
 
             if (settings.Endpoint == default && builder.Configuration.GetConnectionString(connectionName) is string connectionString)
             {
-                settings.Endpoint = ParseEndpointFromConnectionString(connectionString);
+                var endpoint = ParseEndpointFromConnectionString(connectionString);
+                if (endpoint != null)
+                {
+                    settings.Endpoint = endpoint;
+                }
             }
 
             configureSettings?.Invoke(settings);

--- a/src/Client/WahaSettings.cs
+++ b/src/Client/WahaSettings.cs
@@ -15,6 +15,6 @@
         /// <summary>
         /// Gets or sets the endpoint URI for the Waha API.
         /// </summary>
-        public Uri Endpoint { get; set; }
+        public Uri Endpoint { get; set; } = new Uri(DEFAULT_WAHA_ENDPOINT);
     }
 }

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -70,10 +70,13 @@ class Program
         Console.WriteLine("Select chat id");
         var chatId = Console.ReadLine();
 
-        var messages = await wahaApiClient.GetChatMessagesAsync(session.Name, chatId);
-        foreach (var message in messages)
+        if(!string.IsNullOrWhiteSpace(chatId))
         {
-            Console.WriteLine($"Message @ {message.Timestamp} from {message.From} to {message.To}: {message.Body}");
+            var messages = await wahaApiClient.GetChatMessagesAsync(session.Name, chatId);
+            foreach (var message in messages)
+            {
+                Console.WriteLine($"Message @ {message.Timestamp} from {message.From} to {message.To}: {message.Body}");
+            }
         }
 
         Console.ReadLine();


### PR DESCRIPTION
- [x] close #43 

This pull request updates the `WahaApiClient` class by making the `CancellationToken` parameter optional (defaulting to `default`) in all public asynchronous methods. This change improves usability, allowing callers to omit the `CancellationToken` when it's not needed, which simplifies method invocations throughout the codebase. Additionally, the code now uses nullable value types in some query string dictionary constructions for consistency.