### PR TITLE
Feature/api key

### DIFF
--- a/src/Client/WahaApiClient.cs
+++ b/src/Client/WahaApiClient.cs
@@ -27,12 +27,24 @@ namespace Waha
         private readonly HttpClient _httpClient;
         private readonly ILogger<WahaApiClient> _logger;
 
+        public WahaApiClient(string wahaHostUrl, string apiKey, ILogger<WahaApiClient>? logger = null)
+            : this(GetWahaHttpClient(wahaHostUrl, apiKey), logger)
+        { 
+        }
+
         public WahaApiClient(HttpClient httpClient, ILogger<WahaApiClient>? logger = null)
         {
             _httpClient = httpClient;
             _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<WahaApiClient>.Instance;
 
             _logger.LogDebug("WahaApiClient initialized with base address: {BaseAddress}", httpClient.BaseAddress);
+        }
+
+        private static HttpClient GetWahaHttpClient(string wahaHostUrl, string apiKey) 
+        {
+            HttpClient client = new HttpClient() { BaseAddress = new Uri(wahaHostUrl) };
+            client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+            return client;
         }
 
         #region [ SESSIONS ]

--- a/src/Client/WahaEntities.cs
+++ b/src/Client/WahaEntities.cs
@@ -3,20 +3,28 @@ using System.Text.Json.Serialization;
 
 namespace Waha
 {
-    public class UnixTimestampConverter : JsonConverter<DateTime>
+    public class UnixTimestampConverter : JsonConverter<long>
     {
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt64(out long timestamp))
+            if (reader.TokenType == JsonTokenType.Number)
             {
-                return DateTimeOffset.FromUnixTimeSeconds(timestamp).DateTime;
+                if (reader.TryGetInt64(out long value))
+                    return value;
             }
-            throw new JsonException("Invalid timestamp format");
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                if (long.TryParse(reader.GetString(), out long parsed))
+                    return parsed;
+            }
+
+            throw new JsonException("Invalid timestamp format.");
         }
 
-        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(new DateTimeOffset(value).ToUnixTimeSeconds());
+            writer.WriteNumberValue(value);
         }
     }
 
@@ -31,22 +39,26 @@ namespace Waha
         public string Name { get; set; } = default!;
 
         [JsonPropertyName("me")]
-        public SessionUser Me { get; set; } = default!;
+        public SessionUser? User { get; set; } = default!;
 
         [JsonPropertyName("assignedWorker")]
-        public string AssignedWorker { get; set; } = default!;
+        public string? AssignedWorker { get; set; } = default!;
 
+        /// <summary>
+        /// Valid values are: "STOPPED" or "STARTING" or "SCAN_QR_CODE" or "WORKING" or"FAILED"
+        /// </summary>
         [JsonPropertyName("status")]
         public string Status { get; set; } = default!;
 
         [JsonPropertyName("config")]
-        public SessionConfig Config { get; set; } = default!;
+        public SessionConfig? Config { get; set; } = default!;
     }
 
     /// <summary>
     /// A minimal version of session data.
     /// Used by endpoints that return a lighter session structure.
     /// </summary>
+    [Obsolete("Replace this by Session")]
     public record SessionShort
     {
         [JsonPropertyName("name")]
@@ -271,11 +283,8 @@ namespace Waha
     /// </summary>
     public record AuthRequestCodeResponse
     {
-        [JsonPropertyName("success")]
-        public bool Success { get; set; }
-
-        [JsonPropertyName("message")]
-        public string? Message { get; set; }
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
     }
 
     #endregion
@@ -308,7 +317,7 @@ namespace Waha
     public record Message
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; } = default!;
+        public MessageId Id { get; set; } = default!;
 
         [JsonPropertyName("timestamp")]
         [JsonConverter(typeof(UnixTimestampConverter))]
@@ -352,6 +361,44 @@ namespace Waha
 
         [JsonPropertyName("replyTo")]
         public ReplyToMessage? ReplyTo { get; set; }
+
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("deviceType")]
+        public string? DeviceType { get; set; }
+
+        [JsonPropertyName("isForwarded")]
+        public bool IsForwarded { get; set; }
+
+        [JsonPropertyName("isStatus")]
+        public bool IsStatus { get; set; }
+
+        [JsonPropertyName("isStarred")]
+        public bool IsStarred { get; set; }
+
+        [JsonPropertyName("hasQuotedMsg")]
+        public bool HasQuotedMsg { get; set; }
+
+        [JsonPropertyName("mentionedIds")]
+        public List<string>? MentionedIds { get; set; }
+
+        [JsonPropertyName("links")]
+        public List<object>? Links { get; set; }
+    }
+
+    public record MessageId
+    {
+        [JsonPropertyName("fromMe")]
+        public bool FromMe { get; set; }
+        [JsonPropertyName("remote")]
+        public string Remote { get; set; } = default!;
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = default!;
+        [JsonPropertyName("self")]
+        public string Self { get; set; } = default!;
+        [JsonPropertyName("_serialized")]
+        public string Serialized { get; set; } = default!;
     }
 
     /// <summary>

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -32,31 +32,30 @@ class Program
                     break;
                 case "SMS":
                     var authSmsRequestCodeResponse = await wahaApiClient.RequestAuthCodeAsync(activeSession.Name, new AuthCodeRequest() { PhoneNumber = "17824095342", Method = "SMS" });
-                    if (!authSmsRequestCodeResponse.Success)
+                    if (!string.IsNullOrWhiteSpace(authSmsRequestCodeResponse.Code))
                     {
-                        Console.WriteLine("Auth Code Error: " + authSmsRequestCodeResponse.Message);
+                        Console.WriteLine("Auth Code Error: " + authSmsRequestCodeResponse.Code);
                     }
                     break;
                 case "VOICE":
                     var authVoiceRequestCodeResponse = await wahaApiClient.RequestAuthCodeAsync(activeSession.Name, new AuthCodeRequest() { PhoneNumber = "17824095342", Method = "VOICE" });
-                    if (!authVoiceRequestCodeResponse.Success)
+                    if (!string.IsNullOrWhiteSpace(authVoiceRequestCodeResponse.Code))
                     {
-                        Console.WriteLine("Auth Code Error: " + authVoiceRequestCodeResponse.Message);
+                        Console.WriteLine("Auth Code Error: " + authVoiceRequestCodeResponse.Code);
                     }
                     break;
                 case "":
                     var authRequestCodeResponse = await wahaApiClient.RequestAuthCodeAsync(activeSession.Name, new AuthCodeRequest() { PhoneNumber = "17824095342", Method = "" });
-                    if (!authRequestCodeResponse.Success)
+                    if (!string.IsNullOrWhiteSpace(authRequestCodeResponse.Code))
                     {
-                        Console.WriteLine("Auth Code Error: " + authRequestCodeResponse.Message);
+                        Console.WriteLine("Auth Code Error: " + authRequestCodeResponse.Code);
                     }
                     break;
             }
         }
 
         var session = await wahaApiClient.GetSessionAsync(activeSession.Name);
-        var me = session.Me;
-        Console.WriteLine($"Logged in as {me.PushName} ({me.Id})");
+        Console.WriteLine($"Logged in as {session.User.PushName} ({session.User.Id})");
 
         var profile = await wahaApiClient.GetProfileAsync(session.Name);
         Console.WriteLine($"Profile: {profile.Name} ({profile.Id})");


### PR DESCRIPTION
- [x] close #46 

This pull request introduces several improvements and updates to the `WahaApiClient` and related data entities. The main focus is on enhancing the flexibility of the API client instantiation, updating data models to better reflect the API's structure, and improving serialization/deserialization logic for timestamps and message identifiers.

**Key changes include:**

### API Client Improvements

* Added a new constructor to `WahaApiClient` that allows instantiation using a `wahaHostUrl` and `apiKey`, which internally creates and configures an `HttpClient` with the appropriate base address and API key header. [[1]](diffhunk://#diff-a738c6b86abce2c86972a458c274fd6a6e281f17333217da340e2bc6b2615aefR30-R34) [[2]](diffhunk://#diff-a738c6b86abce2c86972a458c274fd6a6e281f17333217da340e2bc6b2615aefR43-R49)

### Data Model Updates

* Updated the `Session` record:
  - Renamed the `Me` property to `User` and made it nullable.
  - Made `AssignedWorker` and `Config` properties nullable.
  - Marked `SessionShort` as obsolete, recommending the use of `Session` instead.
* Changed the `AuthRequestCodeResponse` model to return a `code` string instead of `success` and `message` fields, aligning with updated API responses.

### Message Entity Enhancements

* Refactored the `Message` record:
  - Changed the type of `Id` from `string` to a new `MessageId` record, which provides a structured representation of message identifiers.
  - Added new properties to support richer message metadata, including `Type`, `DeviceType`, `IsForwarded`, `IsStatus`, `IsStarred`, `HasQuotedMsg`, `MentionedIds`, and `Links`.
  - Introduced the `MessageId` record to encapsulate message ID details. [[1]](diffhunk://#diff-04042356aff70f273bbd5eb58c94a4d37f04aaf9606446580975dc0baba0eb10L311-R320) [[2]](diffhunk://#diff-04042356aff70f273bbd5eb58c94a4d37f04aaf9606446580975dc0baba0eb10R364-R401)

### Serialization Logic

* Modified the `UnixTimestampConverter` to handle `long` values instead of `DateTime`, improving compatibility with Unix timestamp fields in the API. The converter now reads both numeric and string representations of timestamps and writes them as numbers.